### PR TITLE
fixes issue i just opened.

### DIFF
--- a/src/pv/core.py
+++ b/src/pv/core.py
@@ -80,8 +80,8 @@ class Log(object):
                 try:
                     try:
                         while True:
-                            self.serialId += 1
                             tx = pickle.load(log)
+                            self.serialId += 1
                             sentry = pickle.load(log);
                             assert self.serialId == sentry.serialId                                                        
                             yield tx


### PR DESCRIPTION
increment serial id only after we successfully load a transaction.  otherwise we create an invalid Sentry entry
